### PR TITLE
Correct the second argument passed to tmpl.Execute

### DIFF
--- a/listings/02/template_3.go
+++ b/listings/02/template_3.go
@@ -25,9 +25,6 @@ UnitPrice: {{.UnitPrice}}
 Quantity: {{.Quantity}}
 `)
 
-		// 获取 URL 参数的值
-		val := r.URL.Query().Get("val")
-
 		// 根据 URL 查询参数的值创建 Inventory 实例
 		inventory := &Inventory{
 			SKU:  r.URL.Query().Get("sku"),
@@ -39,7 +36,7 @@ Quantity: {{.Quantity}}
 		inventory.Quantity, _ = strconv.ParseInt(r.URL.Query().Get("quantity"), 10, 64)
 
 		// 调用模板对象的渲染方法
-		err = tmpl.Execute(w, val)
+		err = tmpl.Execute(w, inventory)
 		if err != nil {
 			fmt.Fprintf(w, "Execute: %v", err)
 			return

--- a/listings/02/template_4.go
+++ b/listings/02/template_4.go
@@ -31,9 +31,6 @@ Quantity: {{.Quantity}}
 Subtotal: {{.Subtotal}}
 `)
 
-		// 获取 URL 参数的值
-		val := r.URL.Query().Get("val")
-
 		// 根据 URL 查询参数的值创建 Inventory 实例
 		inventory := &Inventory{
 			SKU:  r.URL.Query().Get("sku"),
@@ -45,7 +42,7 @@ Subtotal: {{.Subtotal}}
 		inventory.Quantity, _ = strconv.ParseInt(r.URL.Query().Get("quantity"), 10, 64)
 
 		// 调用模板对象的渲染方法
-		err = tmpl.Execute(w, val)
+		err = tmpl.Execute(w, inventory)
 		if err != nil {
 			fmt.Fprintf(w, "Execute: %v", err)
 			return


### PR DESCRIPTION
例子中的根对象从 val 改成了 inventory，代码中 tmpl.Execute 的参数却没改，导致请求会返回
```
Inventory
SKU: Execute: template: test:2:7: executing "test" at <.SKU>: can't evaluate field SKU in type string
```

顺便请问这本书还更新吗？